### PR TITLE
🛡️ Sentinel: Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-23 - Hybrid AI Architecture CSP Strategy
+**Vulnerability:** Absence of Content Security Policy (CSP) in a hybrid AI application, exposing it to XSS and data exfiltration, especially given the mix of local WASM execution and cloud API calls.
+**Learning:** Hybrid architectures require a nuanced CSP: `unsafe-eval` is often necessary for client-side model execution (ONNX/WASM), while `connect-src` must whitelist multiple cloud providers (OpenAI, Alibaba, Baidu, Zhipu) alongside local resources. This creates a larger attack surface than a purely local or purely cloud-based app.
+**Prevention:** Implement a strict CSP that explicitly whitelists all required API endpoints and local resource types. Use `worker-src` and `script-src` carefully to support WASM without opening the door to arbitrary script execution.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Security: Content Security Policy to prevent XSS and unauthorized connections -->
+    <meta http-equiv="Content-Security-Policy" content="
+        default-src 'self';
+        script-src 'self' 'unsafe-eval';
+        style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com;
+        font-src 'self' https://cdnjs.cloudflare.com;
+        img-src 'self' data: blob:;
+        media-src 'self' blob:;
+        connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://hf-mirror.com;
+        worker-src 'self' blob:;
+    ">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">


### PR DESCRIPTION
Added a strict Content Security Policy (CSP) meta tag to `index.html`.
- Whitelisted local origins for scripts, styles, images, and media.
- Allowed `unsafe-eval` for `transformers.js` (WASM/ONNX).
- Whitelisted specific AI API endpoints (OpenAI, Alibaba, Baidu, Zhipu, Hugging Face Mirror).
- Allowed inline styles for dynamic UI components.
- Documented the rationale in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [12723181271143306066](https://jules.google.com/task/12723181271143306066) started by @ycechungAI*