### PR TITLE
🛡️ Sentinel: Add Content Security Policy (CSP) to prevent XSS

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-24 - Content Security Policy (CSP) for AI Apps
+**Vulnerability:** Missing CSP allows arbitrary script execution and data exfiltration via XSS.
+**Learning:** Frontend-heavy AI apps require specific CSP configurations: `connect-src` must whitelist all AI service providers (OpenAI, HuggingFace, etc.), and `wasm-unsafe-eval` is necessary for local model execution (ONNX Runtime via transformers.js).
+**Prevention:** Implement a strict CSP that whitelists only necessary API endpoints and script sources, blocking unauthorized external connections and inline scripts where possible.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'wasm-unsafe-eval' https://cdnjs.cloudflare.com; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://github.com https://user-attachments.githubusercontent.com; media-src 'self' blob:; connect-src 'self' https://huggingface.co https://hf-mirror.com https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn; font-src 'self' https://cdnjs.cloudflare.com; worker-src 'self' blob:;">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">


### PR DESCRIPTION
Added a strict Content Security Policy (CSP) to `index.html` to mitigate XSS risks and restrict unauthorized external connections. The policy whitelists necessary scripts, styles, and API endpoints for the AI application. Verified with Playwright.

---
*PR created automatically by Jules for task [10617148565104625708](https://jules.google.com/task/10617148565104625708) started by @ycechungAI*