### PR TITLE
🛡️ Sentinel: Add Content Security Policy to index.html

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2026-02-12 - Missing Content Security Policy
+**Vulnerability:** The application lacked a Content Security Policy (CSP), allowing unrestricted loading of external scripts, styles, and connections.
+**Learning:** Client-side AI applications using libraries like `@xenova/transformers` often require specific CSP exceptions (`unsafe-eval`, `cdn.jsdelivr.net` for ONNX Runtime WASM) that are not immediately obvious without deep inspection of vendor code.
+**Prevention:** Implement a strict CSP that whitelists only necessary domains, including specific AI provider endpoints and required CDNs, while keeping `unsafe-eval` constrained to trusted scripts if unavoidable.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' https://cdnjs.cloudflare.com https://cdn.jsdelivr.net 'unsafe-eval'; style-src 'self' https://cdnjs.cloudflare.com 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: https://github.com; media-src 'self' blob:; connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://huggingface.co https://cdn.jsdelivr.net;">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">


### PR DESCRIPTION
Added a Content Security Policy (CSP) meta tag to `index.html` to enhance security by restricting resource loading and script execution.

**Changes:**
- Inserted `<meta http-equiv="Content-Security-Policy" ...>` in `index.html`.
- Updated `.jules/sentinel.md` with security learnings regarding CSP for client-side AI apps.

**Verification:**
- Verified the tag syntax and placement in `index.html`.
- Confirmed the allowed domains match the application's configuration in `cloudAPI.js` and `vendor/transformers.js`.

---
*PR created automatically by Jules for task [10745990852809378313](https://jules.google.com/task/10745990852809378313) started by @ycechungAI*