### PR TITLE
🛡️ Sentinel: Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-24 - Client-Side AI CSP Requirements
+**Vulnerability:** Lack of Content Security Policy (CSP) allowing potential XSS or data exfiltration.
+**Learning:** Client-side AI libraries like `transformers.js` (ONNX Runtime Web) require `unsafe-eval` for WASM execution and `blob:` for Web Workers. They also fetch models from `huggingface.co` and runtime files from `cdn.jsdelivr.net`.
+**Prevention:** Use a tailored CSP that permits these specific sources while restricting others, rather than disabling CSP or using `unsafe-inline` everywhere.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' https://cdnjs.cloudflare.com 'unsafe-inline'; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://cdn.jsdelivr.net https://huggingface.co https://*.huggingface.co; worker-src 'self' blob: https://cdn.jsdelivr.net;">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
Added a strict Content Security Policy (CSP) to `index.html` to enhance security by restricting resource loading to trusted domains. The policy allows necessary scripts (transformers.js from jsDelivr), styles (FontAwesome), images/media (self, blob), and API connections (OpenAI, DashScope, Baidu, etc.), while blocking unauthorized sources.

Also added a journal entry in `.jules/sentinel.md` documenting the specific CSP requirements for client-side AI applications.

---
*PR created automatically by Jules for task [8244270778796945997](https://jules.google.com/task/8244270778796945997) started by @ycechungAI*