### PR TITLE
🛡️ Sentinel: Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-23 - Missing Content Security Policy
+**Vulnerability:** The application lacked a Content Security Policy (CSP) header or meta tag, allowing potential execution of malicious scripts from arbitrary sources and unauthorized data exfiltration.
+**Learning:** Even client-side AI apps need strict CSPs. AI libraries often require `unsafe-eval` for WASM or optimization, which weakens CSP, so other directives must be as strict as possible (whitelisting only specific API endpoints).
+**Prevention:** Implement a strict CSP early in development. For AI apps using libraries like `transformers.js`, explicitly whitelist necessary model CDNs (e.g., Hugging Face) and API endpoints, while keeping `script-src` and `connect-src` as restricted as possible.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="
+        default-src 'self';
+        script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net;
+        style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com;
+        font-src 'self' https://cdnjs.cloudflare.com;
+        img-src 'self' data: blob:;
+        media-src 'self' blob:;
+        connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://cdn.jsdelivr.net https://huggingface.co https://*.huggingface.co;
+        worker-src 'self' blob:;
+    ">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">


### PR DESCRIPTION
This PR adds a Content Security Policy (CSP) meta tag to `index.html`. This is a critical security enhancement that restricts the sources from which scripts, styles, images, and other resources can be loaded.

**Changes:**
-   Added `<meta http-equiv="Content-Security-Policy" ...>` to `index.html`.
-   The policy allows scripts from `self`, `unsafe-eval` (required for WASM/ONNX), and `cdn.jsdelivr.net`.
-   Styles are allowed from `self`, `unsafe-inline`, and `cdnjs.cloudflare.com`.
-   Images and media are allowed from `self`, `blob:`, and `data:`.
-   Connections (API calls) are restricted to `self` and specific AI provider endpoints (OpenAI, DashScope, Baidu, BigModel, HuggingFace).
-   Documented the change in `.jules/sentinel.md`.

**Verification:**
-   Verified that the CSP meta tag is present.
-   Verified that the application loads without CSP violations in the console using a Playwright script.
-   Manually checked that chat interface and background video load correctly.

---
*PR created automatically by Jules for task [4179503934747428674](https://jules.google.com/task/4179503934747428674) started by @ycechungAI*