### PR TITLE
🛡️ Sentinel: Add Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-24 - Transformers.js Content Security Policy
+**Vulnerability:** Missing Content Security Policy (CSP) allowed potential XSS and data exfiltration.
+**Learning:** `transformers.js` (via ONNX Runtime Web) requires specific CSP directives: `script-src 'unsafe-eval'` (for WASM), `worker-src blob:` (for web workers), and `connect-src` to CDN/model hubs.
+**Prevention:** Use a strict CSP but allow necessary WASM/Worker directives when using client-side AI libraries.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: blob: https://huggingface.co https://cdn.jsdelivr.net; media-src 'self' blob:; connect-src 'self' https://huggingface.co https://cdn.jsdelivr.net https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn; worker-src 'self' blob:;">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">


### PR DESCRIPTION
Added a Content Security Policy (CSP) meta tag to `index.html` to enhance security by restricting resource loading and script execution. Also updated `.jules/sentinel.md` with a journal entry documenting the specific CSP requirements for Transformers.js.

---
*PR created automatically by Jules for task [249277813261468770](https://jules.google.com/task/249277813261468770) started by @ycechungAI*