### PR TITLE
Shield: Add Content Security Policy to index.html

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-24 - Missing Content Security Policy
+**Vulnerability:** The application lacked a Content Security Policy (CSP), leaving it vulnerable to XSS and data exfiltration.
+**Learning:** Even with input sanitization, defense-in-depth is crucial. The app relies on several external APIs (OpenAI, etc.) and CDN resources (fonts, ONNX runtime).
+**Prevention:** Implement a strict CSP that explicitly allows only necessary sources for scripts, styles, fonts, and connections. This limits the impact of any potential XSS vulnerability.

--- a/index.html
+++ b/index.html
@@ -8,6 +8,8 @@
     <link rel="stylesheet" href="chatStyles.css">
     <!-- 引入 Font Awesome 图标库，用于麦克风图标 -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+    <!-- Content Security Policy -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net blob:; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://huggingface.co https://hf-mirror.com https://cdn.jsdelivr.net; worker-src 'self' blob:;">
 </head>
 <body>
 


### PR DESCRIPTION
Sentinel has identified a security gap: Missing Content Security Policy (CSP).

This PR adds a strict CSP meta tag to `index.html` to mitigate XSS and unauthorized data exfiltration risks.

Policy details:
- Default src: 'self'
- Scripts: 'self', 'unsafe-eval' (for ONNX Runtime), cdn.jsdelivr.net, blob:
- Styles: 'self', 'unsafe-inline' (for dynamic UI), cdnjs.cloudflare.com
- Fonts: 'self', cdnjs.cloudflare.com
- Connect: 'self', AI APIs (OpenAI, Qwen, Baidu, Zhipu), HuggingFace, cdn.jsdelivr.net
- Workers: 'self', blob:

Verified that the application loads correctly without console errors blocking essential resources.

---
*PR created automatically by Jules for task [14418633961451360917](https://jules.google.com/task/14418633961451360917) started by @ycechungAI*