### PR TITLE
🛡️ Sentinel: Add Content Security Policy (CSP)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2025-02-23 - Missing Content Security Policy
+**Vulnerability:** Lack of Content Security Policy (CSP) headers or meta tags, allowing potential execution of unauthorized scripts and loading of malicious resources.
+**Learning:** Even with client-side escaping, a robust CSP is a critical defense-in-depth layer against XSS and data injection. Modern web apps using complex libraries like `transformers.js` (WASM, workers) require careful CSP crafting (`unsafe-eval`, `worker-src`) rather than omitting it entirely.
+**Prevention:** Always implement a strict CSP starting with `default-src 'self'` and whitelisting only necessary external resources (CDNs, APIs).

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self' https://huggingface.co https://cdn.jsdelivr.net https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn; worker-src 'self' blob:;">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">


### PR DESCRIPTION
Added a Content Security Policy (CSP) to `index.html` to enhance application security. The policy restricts resource loading to trusted sources, mitigating XSS and data injection risks.

**Changes:**
- Added `<meta http-equiv="Content-Security-Policy" ...>` to `index.html`.
- Updated `.jules/sentinel.md` with a security journal entry.

**Verification:**
- Verified using a temporary Playwright script that the CSP header is present and does not block legitimate application resources (no console errors).
- Confirmed that external AI services (OpenAI, Dashscope, etc.) are whitelisted in `connect-src`.
- Confirmed that `transformers.js` requirements (`unsafe-eval`, `worker-src`) are met.

---
*PR created automatically by Jules for task [6382905988482195736](https://jules.google.com/task/6382905988482195736) started by @ycechungAI*