### PR TITLE
🛡️ Sentinel: Add strict Content Security Policy

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-24 - Missing Content Security Policy
+**Vulnerability:** The application lacked a Content Security Policy (CSP), making it vulnerable to XSS and data injection attacks if input sanitization failed.
+**Learning:** Modern web apps using WASM (like ONNX Runtime) and dynamic UI generation often require specific CSP relaxations (`unsafe-eval`, `unsafe-inline`), but these should be minimized.
+**Prevention:** Implemented a strict CSP that whitelists only necessary domains (CDN for WASM, FontAwesome) and schemes (blob:, data:), while blocking everything else by default.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,17 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <!-- Strict Content Security Policy to prevent XSS and data injection -->
+    <meta http-equiv="Content-Security-Policy" content="
+        default-src 'self';
+        script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net;
+        style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com;
+        font-src 'self' https://cdnjs.cloudflare.com;
+        img-src 'self' data: blob:;
+        media-src 'self' blob:;
+        connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://huggingface.co https://hf-mirror.com https://cdn.jsdelivr.net;
+        worker-src 'self' blob:;
+    ">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">

--- a/server.log
+++ b/server.log
@@ -1,0 +1,68 @@
+
+> bella@1.0.0 start
+> http-server -p 8081 -c-1 --cors --headers='{"Cross-Origin-Opener-Policy": "same-origin", "Cross-Origin-Embedder-Policy": "require-corp"}'
+
+Starting up http-server, serving ./
+
+http-server version: 14.1.1
+
+http-server settings:
+CORS: true
+Cache: -1 seconds
+Connection Timeout: 120 seconds
+Directory Listings: visible
+AutoIndex: visible
+Serve GZIP Files: false
+Serve Brotli Files: false
+Default File Extension: none
+
+Available on:
+  http://127.0.0.1:8081
+  http://192.168.0.2:8081
+Hit CTRL-C to stop the server
+
+[2026-02-23T01:25:58.826Z]  "GET /" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+(node:3170) [DEP0066] DeprecationWarning: OutgoingMessage.prototype._headers is deprecated
+(Use `node --trace-deprecation ...` to show where the warning was created)
+[2026-02-23T01:25:58.923Z]  "GET /style.css" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:58.927Z]  "GET /chatStyles.css" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:59.003Z]  "GET /Bellaicon/Generated%20image.webp" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:59.208Z]  "GET /%E8%A7%86%E9%A2%91%E8%B5%84%E6%BA%90/3D%20%E5%BB%BA%E6%A8%A1%E5%9B%BE%E7%89%87%E5%88%B6%E4%BD%9C.mp4" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:59.293Z]  "GET /core.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:59.300Z]  "GET /chatInterface.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:59.301Z]  "GET /script.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:59.695Z]  "GET /vendor/transformers.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:25:59.699Z]  "GET /cloudAPI.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:00.239Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:00.239Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer_config.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:00.240Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/config.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:00.241Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer.json" Error (404): "Not found"
+[2026-02-23T01:26:00.242Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer_config.json" Error (404): "Not found"
+[2026-02-23T01:26:00.242Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/config.json" Error (404): "Not found"
+[2026-02-23T01:26:00.308Z]  "GET /models/Xenova/whisper-asr/tokenizer.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:00.309Z]  "GET /models/Xenova/whisper-asr/tokenizer_config.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:00.310Z]  "GET /models/Xenova/whisper-asr/tokenizer.json" Error (404): "Not found"
+[2026-02-23T01:26:00.310Z]  "GET /models/Xenova/whisper-asr/tokenizer_config.json" Error (404): "Not found"
+[2026-02-23T01:26:04.761Z]  "GET /%E8%A7%86%E9%A2%91%E8%B5%84%E6%BA%90/%E8%B4%9F%E9%9D%A2/jimeng-2025-07-16-9418-%E5%8F%8C%E6%89%8B%E5%8F%89%E8%85%B0%EF%BC%8C%E5%98%B4%E5%B7%B4%E4%B8%80%E7%9B%B4%E5%9C%A8%E5%98%9F%E5%9B%94%EF%BC%8C%E8%A1%A8%E6%83%85%E5%BE%AE%E5%BE%AE%E7%94%9F%E6%B0%94.mp4" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.503Z]  "GET /" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.521Z]  "GET /style.css" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.521Z]  "GET /chatStyles.css" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.535Z]  "GET /core.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.535Z]  "GET /chatInterface.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.536Z]  "GET /script.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.536Z]  "GET /Bellaicon/Generated%20image.webp" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.537Z]  "GET /%E8%A7%86%E9%A2%91%E8%B5%84%E6%BA%90/3D%20%E5%BB%BA%E6%A8%A1%E5%9B%BE%E7%89%87%E5%88%B6%E4%BD%9C.mp4" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.548Z]  "GET /vendor/transformers.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.572Z]  "GET /cloudAPI.js" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.849Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.849Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer_config.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.850Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/config.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.851Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer.json" Error (404): "Not found"
+[2026-02-23T01:26:21.851Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/tokenizer_config.json" Error (404): "Not found"
+[2026-02-23T01:26:21.853Z]  "GET /models/Xenova/LaMini-Flan-T5-77M/config.json" Error (404): "Not found"
+[2026-02-23T01:26:21.905Z]  "GET /models/Xenova/whisper-asr/tokenizer.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.906Z]  "GET /models/Xenova/whisper-asr/tokenizer_config.json" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+[2026-02-23T01:26:21.906Z]  "GET /models/Xenova/whisper-asr/tokenizer.json" Error (404): "Not found"
+[2026-02-23T01:26:21.907Z]  "GET /models/Xenova/whisper-asr/tokenizer_config.json" Error (404): "Not found"
+[2026-02-23T01:26:26.707Z]  "GET /%E8%A7%86%E9%A2%91%E8%B5%84%E6%BA%90/jimeng-2025-07-16-1043-%E7%AC%91%E7%9D%80%E4%BC%98%E9%9B%85%E7%9A%84%E5%B7%A6%E5%8F%B3%E6%91%87%E6%99%83%EF%BC%8C%E8%BF%87%E4%B8%80%E4%BC%9A%E5%84%BF%E6%89%8B%E6%89%B6%E7%9D%80%E4%B8%8B%E5%B7%B4%EF%BC%8C%E4%BF%9D%E6%8C%81%E5%BE%AE%E7%AC%91.mp4" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/143.0.7499.4 Safari/537.36"
+http-server stopped.


### PR DESCRIPTION
This PR implements a strict Content Security Policy (CSP) to enhance the security of the application. The CSP whitelists trusted domains for scripts, styles, and connections, while blocking unauthorized resources. It specifically allows 'unsafe-eval' for ONNX Runtime WASM execution and 'unsafe-inline' for dynamic UI updates, which are required by the current architecture. It also documents these changes in the security journal.

---
*PR created automatically by Jules for task [4389967012230426175](https://jules.google.com/task/4389967012230426175) started by @ycechungAI*