### PR TITLE
🛡️ Sentinel: Add Content Security Policy to index.html

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** XSS vulnerability in `chatInterface.js`'s `formatMessage` function where user input was inserted into `innerHTML` without proper escaping.
 **Learning:** The custom formatting logic blindly replaced markdown syntax but failed to escape HTML characters first, assuming the input was safe or that replacements were sufficient.
 **Prevention:** Always escape HTML entities in user input *before* applying any custom formatting or inserting into the DOM. Use `textContent` when possible, or a dedicated sanitization library.
+
+## 2024-05-24 - Missing Content Security Policy
+**Vulnerability:** Missing CSP header in `index.html` allowing potential XSS execution.
+**Learning:** Applications using `transformers.js` (ONNX Runtime Web) require `unsafe-eval` in `script-src` and `blob:` in `worker-src`, which complicates the CSP but is necessary for WASM execution.
+**Prevention:** Implement a CSP that strictly whitelists necessary CDNs (jsdelivr, cloudflare) and API endpoints while allowing the specific directives required for WASM and web workers.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://huggingface.co https://hf-mirror.com https://cdn.jsdelivr.net; img-src 'self' data: blob:; media-src 'self' blob:; worker-src 'self' blob:;">
     <title>Bella - Your AI Companion</title>
     <link rel="stylesheet" href="style.css">
     <link rel="stylesheet" href="chatStyles.css">


### PR DESCRIPTION
This PR adds a Content Security Policy (CSP) to `index.html` as a security enhancement. 

**Changes:**
- Inserted a `<meta http-equiv="Content-Security-Policy">` tag.
- Configured directives to allow necessary scripts, styles, and connections for the application to function (including `transformers.js` requirements).
- Updated `.jules/sentinel.md` with a new journal entry documenting the CSP implementation and learnings.

**Verification:**
- Verified using a Playwright script that the CSP meta tag is present and no console errors (CSP violations) occur during page load.
- Manual inspection of the CSP string against codebase requirements.

---
*PR created automatically by Jules for task [439732986513693332](https://jules.google.com/task/439732986513693332) started by @ycechungAI*