### PR TITLE
🛡️ Sentinel: [Security Enhancement] Add timeout to external API calls

### DIFF
--- a/cloudAPI.js
+++ b/cloudAPI.js
@@ -106,6 +106,26 @@ Always maintain this warm, elegant, and authentic personality, helping users fee
         };
     }
 
+    // Enhanced fetch with timeout to prevent hanging API calls
+    async fetchWithTimeout(url, options = {}, timeout = 10000) {
+        const controller = new AbortController();
+        const id = setTimeout(() => controller.abort(), timeout);
+        try {
+            const response = await fetch(url, {
+                ...options,
+                signal: controller.signal
+            });
+            clearTimeout(id);
+            return response;
+        } catch (error) {
+            clearTimeout(id);
+            if (error.name === 'AbortError') {
+                throw new Error('API request timed out. Please try again later.');
+            }
+            throw error;
+        }
+    }
+
     // Call cloud API for conversation
     async chat(userMessage) {
         const config = this.apiConfigs[this.currentProvider];
@@ -154,7 +174,7 @@ Always maintain this warm, elegant, and authentic personality, helping users fee
             ...this.conversationHistory
         ];
 
-        const response = await fetch(config.baseURL, {
+        const response = await this.fetchWithTimeout(config.baseURL, {
             method: 'POST',
             headers: config.headers,
             body: JSON.stringify({
@@ -186,7 +206,7 @@ Always maintain this warm, elegant, and authentic personality, helping users fee
             ...this.conversationHistory
         ];
 
-        const response = await fetch(config.baseURL, {
+        const response = await this.fetchWithTimeout(config.baseURL, {
             method: 'POST',
             headers: config.headers,
             body: JSON.stringify({
@@ -222,7 +242,7 @@ Always maintain this warm, elegant, and authentic personality, helping users fee
 
         const url = `${config.baseURL}?access_token=${config.accessToken}`;
         
-        const response = await fetch(url, {
+        const response = await this.fetchWithTimeout(url, {
             method: 'POST',
             headers: config.headers,
             body: JSON.stringify({
@@ -251,7 +271,7 @@ Always maintain this warm, elegant, and authentic personality, helping users fee
             ...this.conversationHistory
         ];
 
-        const response = await fetch(config.baseURL, {
+        const response = await this.fetchWithTimeout(config.baseURL, {
             method: 'POST',
             headers: config.headers,
             body: JSON.stringify({


### PR DESCRIPTION
🚨 **Severity**: MEDIUM (Enhancement)
💡 **Vulnerability**: The application previously made `fetch` requests to external cloud AI APIs without any timeout mechanisms. If the upstream provider were unresponsive or slow, the browser connection could hang indefinitely, potentially locking up the UI or exhausting connection pools (DoS vulnerability).
🎯 **Impact**: An attacker or network issue could cause the application's thinking state to remain active forever, degrading the user experience and consuming local resources.
🔧 **Fix**: Implemented a `fetchWithTimeout` helper function using an `AbortController` in `cloudAPI.js`. This enforces a 10-second timeout on all outbound requests (`callOpenAI`, `callQwen`, `callErnie`, `callGLM`), ensuring the promise resolves or safely aborts with an error message if the API doesn't respond.
✅ **Verification**: Start the local server (`npm start`) and trigger a chat message using one of the cloud providers. If the provider's IP is blocked or artificially delayed, the UI will successfully return an "API request timed out" error instead of hanging.

---
*PR created automatically by Jules for task [11986996488476938696](https://jules.google.com/task/11986996488476938696) started by @ycechungAI*