### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in download_models.js

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -104,3 +104,8 @@
 **Vulnerability:** The Content Security Policy (CSP) for `test-chat.html` contained `script-src 'unsafe-inline'`, which effectively neutralized the policy's protection against Cross-Site Scripting (XSS) attacks by allowing arbitrary inline scripts to execute.
 **Learning:** Even in test files or auxiliary pages, using `'unsafe-inline'` in a CSP significantly degrades the application's overall security posture. Inline scripts and inline event handlers (like `onclick`) should be avoided.
 **Prevention:** Extracted the inline `<script type="module">` and inline event handlers from `test-chat.html` into a separate external file (`testChat.js`). This allowed the removal of `'unsafe-inline'` from the `script-src` directive, strictly enforcing a safer policy.
+
+## 2026-04-08 - Command Injection Risk in Shell Executions
+**Vulnerability:** The script `download_models.js` utilized `child_process.exec` to run `git clone`, dynamically constructing the shell command via string interpolation (`git clone --depth 1 ${modelUrl} ${targetDir}`).
+**Learning:** Constructing commands via string concatenation and running them with `exec` invokes the system shell, which can inadvertently interpret shell metacharacters. If variables like `modelUrl` or `targetDir` are ever influenced by untrusted external sources or modified without escaping, it leads to Command Injection, allowing arbitrary code execution.
+**Prevention:** Always use `child_process.execFile` or `child_process.spawn` instead of `exec` when executing binaries. These functions accept an array of arguments, bypassing the shell interpreter entirely and safely treating user input as literal parameters rather than executable code.

--- a/download_models.js
+++ b/download_models.js
@@ -1,7 +1,7 @@
 // download_models.js
 // This script downloads the required models from Hugging Face to the local 'models' directory.
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs/promises';
@@ -19,12 +19,12 @@ const models = {
 // Define where to save the models
 const modelsPath = path.resolve(__dirname, 'models');
 
-// Promisify exec
-const execPromise = (command) => {
+// Promisify execFile
+const execFilePromise = (file, args) => {
     return new Promise((resolve, reject) => {
-        exec(command, (error, stdout, stderr) => {
+        execFile(file, args, (error, stdout, stderr) => {
             if (error) {
-                console.error(`exec error: ${error}`);
+                console.error(`execFile error: ${error}`);
                 return reject(error);
             }
             console.log(stdout);
@@ -43,7 +43,7 @@ async function download() {
         console.log(`\nCloning ${modelName} from ${modelUrl}...`);
         try {
             // Use --depth 1 for a shallow clone to save space and time
-            await execPromise(`git clone --depth 1 ${modelUrl} ${targetDir}`);
+            await execFilePromise('git', ['clone', '--depth', '1', modelUrl, targetDir]);
             console.log(`Successfully cloned ${modelName}`);
         } catch (error) {
             console.error(`\nFailed to clone ${modelName}:`, error);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in download_models.js

🚨 Severity: CRITICAL
💡 Vulnerability: The script `download_models.js` utilized `child_process.exec` to run `git clone`, dynamically constructing the shell command via string interpolation (`git clone --depth 1 ${modelUrl} ${targetDir}`). Constructing commands via string concatenation and running them with `exec` invokes the system shell, which can inadvertently interpret shell metacharacters, leading to Command Injection.
🎯 Impact: If variables like `modelUrl` or `targetDir` are ever influenced by untrusted external sources, it allows arbitrary code execution on the host machine.
🔧 Fix: Replaced `child_process.exec` with `child_process.execFile`. `execFile` accepts an array of arguments, bypassing the shell interpreter entirely and safely treating inputs as literal parameters.
✅ Verification: Ran `node download_models.js` to ensure models still clone properly. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [7383833995416305943](https://jules.google.com/task/7383833995416305943) started by @ycechungAI*