### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Command Injection Risk in download_models.js

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -104,3 +104,8 @@
 **Vulnerability:** The Content Security Policy (CSP) for `test-chat.html` contained `script-src 'unsafe-inline'`, which effectively neutralized the policy's protection against Cross-Site Scripting (XSS) attacks by allowing arbitrary inline scripts to execute.
 **Learning:** Even in test files or auxiliary pages, using `'unsafe-inline'` in a CSP significantly degrades the application's overall security posture. Inline scripts and inline event handlers (like `onclick`) should be avoided.
 **Prevention:** Extracted the inline `<script type="module">` and inline event handlers from `test-chat.html` into a separate external file (`testChat.js`). This allowed the removal of `'unsafe-inline'` from the `script-src` directive, strictly enforcing a safer policy.
+
+## 2026-04-13 - Command Injection in Model Download Script
+**Vulnerability:** The script `download_models.js` used `child_process.exec` with string concatenation to run `git clone`, introducing a potential command injection vulnerability if model URLs or target directories were ever influenced by untrusted input.
+**Learning:** Even in utility or build scripts like model downloaders, using `exec` with dynamically constructed strings is an anti-pattern. While the inputs in this specific case were hardcoded, establishing a secure baseline is critical to prevent future regressions if the script is modified to accept external configuration.
+**Prevention:** Always use `child_process.execFile` (or `spawn`) instead of `exec` when executing shell commands, and pass arguments as an array rather than a single concatenated string. This ensures that arguments are safely escaped and passed directly to the executable, preventing shell injection attacks.

--- a/download_models.js
+++ b/download_models.js
@@ -1,7 +1,7 @@
 // download_models.js
 // This script downloads the required models from Hugging Face to the local 'models' directory.
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs/promises';
@@ -19,12 +19,12 @@ const models = {
 // Define where to save the models
 const modelsPath = path.resolve(__dirname, 'models');
 
-// Promisify exec
-const execPromise = (command) => {
+// Promisify execFile
+const execFilePromise = (file, args) => {
     return new Promise((resolve, reject) => {
-        exec(command, (error, stdout, stderr) => {
+        execFile(file, args, (error, stdout, stderr) => {
             if (error) {
-                console.error(`exec error: ${error}`);
+                console.error(`execFile error: ${error}`);
                 return reject(error);
             }
             console.log(stdout);
@@ -43,7 +43,7 @@ async function download() {
         console.log(`\nCloning ${modelName} from ${modelUrl}...`);
         try {
             // Use --depth 1 for a shallow clone to save space and time
-            await execPromise(`git clone --depth 1 ${modelUrl} ${targetDir}`);
+            await execFilePromise('git', ['clone', '--depth', '1', modelUrl, targetDir]);
             console.log(`Successfully cloned ${modelName}`);
         } catch (error) {
             console.error(`\nFailed to clone ${modelName}:`, error);


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Command Injection Risk in `download_models.js`

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `download_models.js` script used `child_process.exec` with a dynamically constructed string to execute `git clone`. While currently using hardcoded URLs and paths, using `exec` in this manner establishes an insecure baseline that could easily lead to command injection if the script were later updated to accept external or untrusted configuration arguments.
🎯 **Impact:** If an attacker could control any portion of the `modelUrl` or `targetDir` variables (e.g. through a manipulated configuration file or environment variable), they could append arbitrary shell commands that would be executed with the privileges of the script runner.
🔧 **Fix:** Replaced `child_process.exec` with `child_process.execFile` and updated the wrapping Promise helper. The `git` executable is now called directly with its arguments passed as a safe array, preventing the shell from misinterpreting the inputs as chained commands. Also updated the Sentinel journal with these learnings.
✅ **Verification:**
1. Ran `npm run download` to ensure the script functions as expected and successfully pulls models.
2. Verified the CSP tester scripts pass.

---
*PR created automatically by Jules for task [532644464612668865](https://jules.google.com/task/532644464612668865) started by @ycechungAI*