### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection risk in model download script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -104,3 +104,7 @@
 **Vulnerability:** The Content Security Policy (CSP) for `test-chat.html` contained `script-src 'unsafe-inline'`, which effectively neutralized the policy's protection against Cross-Site Scripting (XSS) attacks by allowing arbitrary inline scripts to execute.
 **Learning:** Even in test files or auxiliary pages, using `'unsafe-inline'` in a CSP significantly degrades the application's overall security posture. Inline scripts and inline event handlers (like `onclick`) should be avoided.
 **Prevention:** Extracted the inline `<script type="module">` and inline event handlers from `test-chat.html` into a separate external file (`testChat.js`). This allowed the removal of `'unsafe-inline'` from the `script-src` directive, strictly enforcing a safer policy.
+## 2024-05-24 - Command Injection via child_process.exec
+**Vulnerability:** The `download_models.js` script used `child_process.exec` to execute shell commands, constructing the command string dynamically with URL and path variables. This created a potential command injection vulnerability if those variables were ever controlled by an external source.
+**Learning:** `child_process.exec` passes the constructed string to a shell for execution, meaning shell metacharacters within variables can be interpreted as part of the command.
+**Prevention:** Always use `child_process.execFile` or `child_process.spawn` when passing dynamic arguments to external commands. These functions take the executable and its arguments as an array, bypassing the shell and eliminating the risk of command injection.

--- a/download_models.js
+++ b/download_models.js
@@ -1,7 +1,7 @@
 // download_models.js
 // This script downloads the required models from Hugging Face to the local 'models' directory.
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs/promises';
@@ -19,10 +19,10 @@ const models = {
 // Define where to save the models
 const modelsPath = path.resolve(__dirname, 'models');
 
-// Promisify exec
-const execPromise = (command) => {
+// Promisify execFile
+const execPromise = (command, args) => {
     return new Promise((resolve, reject) => {
-        exec(command, (error, stdout, stderr) => {
+        execFile(command, args, (error, stdout, stderr) => {
             if (error) {
                 console.error(`exec error: ${error}`);
                 return reject(error);
@@ -43,7 +43,7 @@ async function download() {
         console.log(`\nCloning ${modelName} from ${modelUrl}...`);
         try {
             // Use --depth 1 for a shallow clone to save space and time
-            await execPromise(`git clone --depth 1 ${modelUrl} ${targetDir}`);
+            await execPromise('git', ['clone', '--depth', '1', modelUrl, targetDir]);
             console.log(`Successfully cloned ${modelName}`);
         } catch (error) {
             console.error(`\nFailed to clone ${modelName}:`, error);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `download_models.js` script used `child_process.exec` to execute the `git clone` command, directly concatenating `modelUrl` and `targetDir`. This posed a potential command injection risk if these variables were ever dynamically controlled or manipulated.
🎯 Impact: Exploitation could allow arbitrary code execution on the system running the download script.
🔧 Fix: Refactored `download_models.js` to use `child_process.execFile` instead of `exec`. By passing the command arguments as an array, the execution directly invokes the executable without passing through a shell, preventing any shell metacharacters in the variables from being interpreted as secondary commands.
✅ Verification: Ran `node download_models.js` to confirm that the script still correctly clones the models and downloads the speaker embeddings.

---
*PR created automatically by Jules for task [3101324070696789873](https://jules.google.com/task/3101324070696789873) started by @ycechungAI*