### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in model download script

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -104,3 +104,7 @@
 **Vulnerability:** The Content Security Policy (CSP) for `test-chat.html` contained `script-src 'unsafe-inline'`, which effectively neutralized the policy's protection against Cross-Site Scripting (XSS) attacks by allowing arbitrary inline scripts to execute.
 **Learning:** Even in test files or auxiliary pages, using `'unsafe-inline'` in a CSP significantly degrades the application's overall security posture. Inline scripts and inline event handlers (like `onclick`) should be avoided.
 **Prevention:** Extracted the inline `<script type="module">` and inline event handlers from `test-chat.html` into a separate external file (`testChat.js`). This allowed the removal of `'unsafe-inline'` from the `script-src` directive, strictly enforcing a safer policy.
+## 2025-02-23 - Command Injection in Model Download Script
+**Vulnerability:** The `download_models.js` script used `child_process.exec` to run `git clone`, allowing potential command injection if the model URL or target directory contained malicious shell characters.
+**Learning:** Using `exec` invokes a shell, which can interpret shell metacharacters (e.g., `;`, `&`, `|`) present in the input string. This is a common and critical security risk when handling external commands, even in seemingly internal tools.
+**Prevention:** Always use `child_process.execFile` or `spawn` instead of `exec`. These functions execute the target binary directly without invoking a shell, preventing shell injection vulnerabilities. Pass arguments as an array of strings.

--- a/download_models.js
+++ b/download_models.js
@@ -1,7 +1,7 @@
 // download_models.js
 // This script downloads the required models from Hugging Face to the local 'models' directory.
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { fileURLToPath } from 'url';
 import path from 'path';
 import fs from 'fs/promises';
@@ -19,12 +19,12 @@ const models = {
 // Define where to save the models
 const modelsPath = path.resolve(__dirname, 'models');
 
-// Promisify exec
-const execPromise = (command) => {
+// Promisify execFile
+const execPromise = (file, args) => {
     return new Promise((resolve, reject) => {
-        exec(command, (error, stdout, stderr) => {
+        execFile(file, args, (error, stdout, stderr) => {
             if (error) {
-                console.error(`exec error: ${error}`);
+                console.error(`execFile error: ${error}`);
                 return reject(error);
             }
             console.log(stdout);
@@ -43,7 +43,7 @@ async function download() {
         console.log(`\nCloning ${modelName} from ${modelUrl}...`);
         try {
             // Use --depth 1 for a shallow clone to save space and time
-            await execPromise(`git clone --depth 1 ${modelUrl} ${targetDir}`);
+            await execPromise('git', ['clone', '--depth', '1', modelUrl, targetDir]);
             console.log(`Successfully cloned ${modelName}`);
         } catch (error) {
             console.error(`\nFailed to clone ${modelName}:`, error);


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `download_models.js` script used `child_process.exec` to run `git clone`, potentially allowing arbitrary shell commands to be executed if external inputs (like model URLs or directory paths) were maliciously constructed.
🎯 Impact: An attacker could execute arbitrary commands on the system running the build or download process.
🔧 Fix: Replaced `exec` with `execFile` and provided arguments as an array instead of a single concatenated string. This avoids invoking a shell, ensuring the inputs are treated strictly as arguments to the `git` binary.
✅ Verification: Ran `npm run download` to verify the models clone without errors. Checked the source code to ensure `execFile` is correctly used.

---
*PR created automatically by Jules for task [2885922902984690351](https://jules.google.com/task/2885922902984690351) started by @ycechungAI*