### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix multiple CSP tags causing overly restrictive intersections

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -100,6 +100,11 @@
 **Vulnerability:** External API calls to LLM providers (OpenAI, Qwen, Ernie, GLM) were made using native `fetch` without any timeout configuration. This could lead to unhandled hanging connections and resource exhaustion (client-side DoS) if the remote server is unresponsive or the network is unstable.
 **Learning:** The native `fetch` API does not have a default timeout. In AI applications where API generation times can vary significantly or connections can hang, relying on the browser's default timeout (which can be several minutes) severely degrades user experience and ties up resources.
 **Prevention:** Always implement an `AbortController` wrapper for `fetch` calls to enforce a strict timeout (e.g., 10 seconds), ensuring the application can gracefully recover or inform the user of network issues.
+
+## 2026-05-04 - Overly Restrictive CSP via Multiple Meta Tags
+**Vulnerability:** `index.html` contained multiple Content Security Policy (CSP) `<meta>` tags. Browsers enforce the intersection (most restrictive combination) of all provided policies, which inadvertently blocked required `blob:` sources for Web Workers and WASM, breaking core functionality.
+**Learning:** When multiple CSP headers or meta tags are present, the browser enforces *all* of them. A less restrictive policy cannot loosen the restrictions of a stricter policy. This can lead to unexpected breakage, such as `worker-src` or `script-src` failing to load necessary resources if one tag lacks the required permissions (e.g., `blob:`).
+**Prevention:** Ensure that only a single, consolidated, and carefully crafted Content Security Policy is applied to the application to avoid unintended policy intersections.
 ## 2024-05-25 - XSS via Inline Scripts in CSP
 **Vulnerability:** The Content Security Policy (CSP) for `test-chat.html` contained `script-src 'unsafe-inline'`, which effectively neutralized the policy's protection against Cross-Site Scripting (XSS) attacks by allowing arbitrary inline scripts to execute.
 **Learning:** Even in test files or auxiliary pages, using `'unsafe-inline'` in a CSP significantly degrades the application's overall security posture. Inline scripts and inline event handlers (like `onclick`) should be avoided.

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://huggingface.co https://cdn.jsdelivr.net; worker-src blob:; img-src 'self' data: blob:; media-src 'self' blob:;">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <!-- Content Security Policy (CSP) to mitigate XSS and unauthorized data exfiltration -->
     <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self' 'unsafe-eval' https://cdn.jsdelivr.net blob:; style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com; font-src 'self' https://cdnjs.cloudflare.com; img-src 'self' data:; media-src 'self' blob:; connect-src 'self' https://api.openai.com https://dashscope.aliyuncs.com https://aip.baidubce.com https://open.bigmodel.cn https://huggingface.co https://cdn.jsdelivr.net blob:; worker-src 'self' blob:;">


### PR DESCRIPTION
🚨 **Severity:** MEDIUM

💡 **Vulnerability:** `index.html` contained multiple Content Security Policy (CSP) `<meta>` tags. The first tag was more restrictive (lacked `blob:` allowances for `script-src` and `connect-src`).

🎯 **Impact:** Browsers enforce the intersection (most restrictive combination) of all provided CSPs. Because the first tag was overly strict, the application's required `blob:` sources for Web Workers and WASM (used by the ONNX runtime via `transformers.js`) were inadvertently blocked, breaking core AI features.

🔧 **Fix:** Removed the first, redundant `<meta>` tag, leaving only the properly consolidated second CSP tag that correctly whitelists all necessary resources (`blob:`, CDNs, Cloud APIs) while maintaining a strict `default-src 'self'`. Documented this learning in `.jules/sentinel.md`.

✅ **Verification:** Verified by running `npm start` and executing the automated Playwright test `python3 verify_csp.py`, which now reports no CSP violations and correctly loads required local models/resources.

---
*PR created automatically by Jules for task [12751198902192045144](https://jules.google.com/task/12751198902192045144) started by @ycechungAI*