### PR TITLE
🛡️ Sentinel: [MEDIUM] Add input length limits to chat interface

### DIFF
--- a/chatInterface.js
+++ b/chatInterface.js
@@ -285,6 +285,12 @@ class ChatInterface {
         const text = this.messageInput.value.trim();
         if (!text) return;
 
+        // Security: Limit input length to prevent client-side DoS
+        if (text.length > 500) {
+            alert('输入内容过长，请限制在500个字符以内。');
+            return;
+        }
+
         // 添加用户消息
         this.addMessage('user', text);
         


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Add input length limits to chat interface

*   **Severity:** MEDIUM
*   **Vulnerability:** Missing logic-level input length validation. The HTML input had a `maxlength` attribute, but the backend `sendMessage` function lacked a corresponding length check, which can be bypassed via inspect element.
*   **Impact:** Potential client-side DoS or performance degradation from processing excessively large strings (e.g., locking up the browser or causing out-of-memory errors in the AI models or history processing).
*   **Fix:** Added a strict length check (`if (text.length > 500)`) directly inside `sendMessage()` in `chatInterface.js` that alerts the user and returns early if the text exceeds 500 characters.
*   **Verification:** Verified via `node -c chatInterface.js` and a Python Playwright script confirming that the alert fires correctly when input exceeds the limit.

---
*PR created automatically by Jules for task [18291683434549345331](https://jules.google.com/task/18291683434549345331) started by @ycechungAI*